### PR TITLE
Exclude gold & silver standard from matching solutions

### DIFF
--- a/app/src/pages/AlgorithmsPage/AlgorithmsPage.tsx
+++ b/app/src/pages/AlgorithmsPage/AlgorithmsPage.tsx
@@ -8,8 +8,12 @@ import { getAlgorithms } from 'store/actions/AlgorithmsStoreActions';
 import { SnowmanDispatch } from 'store/messages';
 import { Store } from 'store/models';
 
+import { FirstValidMatchingSolution } from '../../utils/constants';
+
 const mapStateToProps = (state: Store): AlgorithmsPageStateProps => ({
-  algorithms: state.AlgorithmsStore.algorithms,
+  algorithms: state.AlgorithmsStore.algorithms.filter(
+    (value) => value.id >= FirstValidMatchingSolution
+  ),
 });
 
 const mapDispatchToProps = (

--- a/app/src/pages/AlgorithmsPage/AlgorithmsPage.tsx
+++ b/app/src/pages/AlgorithmsPage/AlgorithmsPage.tsx
@@ -7,8 +7,7 @@ import { connect } from 'react-redux';
 import { getAlgorithms } from 'store/actions/AlgorithmsStoreActions';
 import { SnowmanDispatch } from 'store/messages';
 import { Store } from 'store/models';
-
-import { FirstValidMatchingSolution } from '../../utils/constants';
+import { FirstValidMatchingSolution } from 'utils/constants';
 
 const mapStateToProps = (state: Store): AlgorithmsPageStateProps => ({
   algorithms: state.AlgorithmsStore.algorithms.filter(

--- a/app/src/utils/constants.ts
+++ b/app/src/utils/constants.ts
@@ -1,1 +1,2 @@
 export const MagicNotPossibleId = -100;
+export const FirstValidMatchingSolution = 3;


### PR DESCRIPTION
Exclude gold & silver standard from matching solutions as they are not really actual matching products.