### PR TITLE
Fix lost subprocess on macOS

### DIFF
--- a/wrapper/src/main.ts
+++ b/wrapper/src/main.ts
@@ -111,6 +111,12 @@ ipcMain.on('reset_launcher', (event) => {
   showLauncherPage();
 });
 
+app.on('activate', () => {
+  if (!mainWindow) {
+    createWindow();
+  }
+});
+
 app.on('ready', () => {
   if (app.commandLine.hasSwitch('headless')) {
     console.log(headlessMessage);
@@ -126,12 +132,6 @@ app.on('window-all-closed', async () => {
     setTimeout(() => {
       app.quit();
     }, 250);
-  }
-});
-
-app.on('activate', () => {
-  if (!mainWindow) {
-    createWindow();
   }
 });
 

--- a/wrapper/src/main.ts
+++ b/wrapper/src/main.ts
@@ -49,6 +49,13 @@ function spawnLocalServer() {
   );
 }
 
+function killLocalServer() {
+  if (backend !== undefined) {
+    backend.kill('SIGINT');
+    backend = undefined;
+  }
+}
+
 function createWindow() {
   // Create the browser window.
   mainWindow = new BrowserWindow({
@@ -114,10 +121,7 @@ app.on('ready', () => {
 });
 
 app.on('window-all-closed', async () => {
-  if (backend !== undefined) {
-    backend.kill('SIGINT');
-    backend = undefined;
-  }
+  killLocalServer();
   if (process.platform !== 'darwin') {
     setTimeout(() => {
       app.quit();
@@ -129,4 +133,8 @@ app.on('activate', () => {
   if (!mainWindow) {
     createWindow();
   }
+});
+
+app.on('quit', () => {
+  killLocalServer();
 });


### PR DESCRIPTION
On macOS, we do not receive the `window-all-closed` when the app is closed with `Cmd`+`Q`. Therefore, we need to add a listener for the `quit` lifecycle event too. This PR includes the fix.