### PR TITLE
Add a proper release mechanism

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -1,6 +1,14 @@
 name: General
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
   lint:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,66 @@
+name: Package
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  package:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Select platform(s)
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+      - name: Get npm cache directory
+        id: npm-cache-dir
+        run: |
+          echo "::set-output name=dir::$(npm config get cache)"
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.npm-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Run (root) npm install
+        run: npm ci
+        working-directory: ./
+      - name: Run (app) npm install
+        run: npm ci
+        working-directory: ./app
+      - name: Run (wrapper) npm install
+        run: npm ci
+        working-directory: ./wrapper
+      - name: Release stack
+        run: npm run release
+        working-directory: ./
+      - name: Upload artifact (Windows)
+        uses: actions/upload-artifact@v2
+        with:
+          name: snowman-win.zip
+          path: ./wrapper/build/*.zip
+        if: matrix.os == 'windows-latest'
+      - name: Upload artifact (MacOS)
+        uses: actions/upload-artifact@v2
+        with:
+          name: snowman.dmg
+          path: ./wrapper/build/*.dmg
+        if: matrix.os == 'macos-latest'
+      - name: Upload artifact (Linux)
+        uses: actions/upload-artifact@v2
+        with:
+          name: snowman-lnx.zip
+          path: ./wrapper/build/*.zip
+        if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,8 @@ jobs:
         shell: bash
         run: |
           mkdir ./artifacts/
-      - uses: actions/download-artifact@v2
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
         with:
           path: ./artifacts/
       - name: Create & Upload Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,21 +66,14 @@ jobs:
       - package
     runs-on: ubuntu-latest
     steps:
-      - name: Download artifact (MacOS)
-        uses: actions/download-artifact@v2
+      - uses: actions/checkout@v2
+      - name: Create directory
+        shell: bash
+        run: |
+          mkdir ./artifacts/
+      - uses: actions/download-artifact@v2
         with:
-          name: snowman.dmg
-          path: /home/runner/snowman.dmg
-      - name: Download artifact (Windows)
-        uses: actions/download-artifact@v2
-        with:
-          name: snowman-win.zip
-          path: /home/runner/snowman-win.zip
-      - name: Download artifact (Linux)
-        uses: actions/download-artifact@v2
-        with:
-          name: snowman-lnx.zip
-          path: /home/runner/snowman-lnx.zip
+          path: ./artifacts/
       - name: Create & Upload Release
         uses: softprops/action-gh-release@v1
         with:
@@ -89,10 +82,9 @@ jobs:
           body: (to be manually added)
           draft: true
           prerelease: false
-          fail_on_unmatched_files: true
           files: |
-            /home/runner/snowman.dmg
-            /home/runner/snowman-lnx.zip
-            /home/runner/snowman-win.zip
+            ./artifacts/*
+            ./LICENSE
+            ./README.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,8 +77,6 @@ jobs:
       - name: Create & Upload Release
         uses: softprops/action-gh-release@v1
         with:
-          name: Release ${{ github.ref }}
-          tag_name: ${{ github.ref }}
           body: (to be manually added)
           draft: true
           prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,10 +78,8 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           body: (to be manually added)
-          draft: true
-          prerelease: false
           files: |
-            ./artifacts/*
+            ./artifacts/**/*
             ./LICENSE
             ./README.md
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,41 +81,18 @@ jobs:
         with:
           name: snowman-lnx.zip
           path: /home/runner/snowman-lnx.zip
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create & Upload Release
+        uses: softprops/action-gh-release@v1
         with:
+          name: Release ${{ github.ref }}
           tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          body: (to be designated)
+          body: (to be manually added)
           draft: true
           prerelease: false
-      - name: Upload release asset (MacOS)
-        uses: actions/upload-release-asset@v1
+          fail_on_unmatched_files: true
+          files: |
+            /home/runner/snowman.dmg
+            /home/runner/snowman-lnx.zip
+            /home/runner/snowman-win.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: /home/runner/snowman.dmg
-          asset_name: snowman.dmg
-          asset_content_type: application/octet-stream
-      - name: Upload release asset (Windows)
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: /home/runner/snowman-win.zip
-          asset_name: snowman-win.zip
-          asset_content_type: application/zip
-      - name: Upload release asset (Linux)
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: /home/runner/snowman-lnx.zip
-          asset_name: snowman-lnx.zip
-          asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,14 +2,11 @@ name: Release
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+    tags:
+      - '**'
 
 jobs:
-  release:
+  package:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -64,3 +61,61 @@ jobs:
           name: snowman-lnx.zip
           path: ./wrapper/build/*.zip
         if: matrix.os == 'ubuntu-latest'
+  release:
+    needs:
+      - package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifact (MacOS)
+        uses: actions/download-artifact@v2
+        with:
+          name: snowman.dmg
+          path: /home/runner/snowman.dmg
+      - name: Download artifact (Windows)
+        uses: actions/download-artifact@v2
+        with:
+          name: snowman-win.zip
+          path: /home/runner/snowman-win.zip
+      - name: Download artifact (Linux)
+        uses: actions/download-artifact@v2
+        with:
+          name: snowman-lnx.zip
+          path: /home/runner/snowman-lnx.zip
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: (to be designated)
+          draft: true
+          prerelease: false
+      - name: Upload release asset (MacOS)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: /home/runner/snowman.dmg
+          asset_name: snowman.dmg
+          asset_content_type: application/octet-stream
+      - name: Upload release asset (Windows)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: /home/runner/snowman-win.zip
+          asset_name: snowman-win.zip
+          asset_content_type: application/zip
+      - name: Upload release asset (Linux)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: /home/runner/snowman-lnx.zip
+          asset_name: snowman-lnx.zip
+          asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           body: (to be manually added)
+          draft: true
           files: |
             ./artifacts/**/*
             ./LICENSE

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 <h1 align="center">Snowman</h1>
 
-#### [![General](https://github.com/HPI-Information-Systems/snowman/actions/workflows/general.yml/badge.svg)](https://github.com/HPI-Information-Systems/snowman/actions/workflows/general.yml) [![Documentation](https://github.com/HPI-Information-Systems/snowman/actions/workflows/docs.yml/badge.svg)](https://github.com/HPI-Information-Systems/snowman/actions/workflows/docs.yml) [![Release](https://github.com/HPI-Information-Systems/snowman/actions/workflows/release.yml/badge.svg)](https://github.com/HPI-Information-Systems/snowman/actions/workflows/release.yml)
+#### [![General](https://github.com/HPI-Information-Systems/snowman/actions/workflows/general.yml/badge.svg)](https://github.com/HPI-Information-Systems/snowman/actions/workflows/general.yml) [![Documentation](https://github.com/HPI-Information-Systems/snowman/actions/workflows/docs.yml/badge.svg)](https://github.com/HPI-Information-Systems/snowman/actions/workflows/docs.yml) [![Release](https://github.com/HPI-Information-Systems/snowman/actions/workflows/package.yml/badge.svg)](https://github.com/HPI-Information-Systems/snowman/actions/workflows/package.yml)
 
 Comparing data matching algorithms is still an unsolved topic in both industry and research.
 With snowman, developers and researchers will be able to compare the performance of different data matching  solutions or improve new algorithms.


### PR DESCRIPTION
This PR adds the following release workflow:

1. Tag a commit on `main` with a name like `v1.2.3` and push the tag to GitHub.
2. A release build will be started - basically the same as a normal package.
3. After all platforms built successfully, a draft release will be created.
4. Edit the draft and supply a body - finally click "release".

I'd suggest to squash-merge this PR directly into `main`.