### PR TITLE
Fix missing content in resized IonSplitPane

### DIFF
--- a/app/src/app/App.View.tsx
+++ b/app/src/app/App.View.tsx
@@ -18,7 +18,7 @@ import 'react-toastify/dist/ReactToastify.css';
 /* Overwrite variables */
 import 'theme/overwrites.css';
 
-import { IonApp, IonSplitPane } from '@ionic/react';
+import { IonApp, IonPage, IonSplitPane } from '@ionic/react';
 import { AppProps } from 'app/AppProps';
 import GlobalLoading from 'components/GlobalLoading/GlobalLoading';
 import SideMenu from 'components/SideMenu/SideMenu';
@@ -34,13 +34,17 @@ const AppView = ({
   useEffect((): void => loadInitialState(), [loadInitialState]);
   return (
     <IonApp>
-      <IonSplitPane when="lg" contentId="main" class="split-pane-fixed">
-        {/*--  Side Menu  --*/}
-        <SideMenu />
+      <IonSplitPane
+        when="lg"
+        contentId="mainViewContentId"
+        class="split-pane-fixed"
+      >
+        {/* Side Menu (mainViewContentId used here!) */}
+        <SideMenu contentId="mainViewContentId" />
         {/* Page Content */}
-        <div id="main">
+        <IonPage id="mainViewContentId">
           {React.createElement(getViewComponentToViewId(currentViewId))}
-        </div>
+        </IonPage>
       </IonSplitPane>
       <ReactTooltip className="tooltip-fixed" html={true} place={'bottom'} />
       <GlobalLoading />

--- a/app/src/components/PageStruct/PageStruct.View.tsx
+++ b/app/src/components/PageStruct/PageStruct.View.tsx
@@ -5,7 +5,6 @@ import {
   IonContent,
   IonHeader,
   IonMenuButton,
-  IonPage,
   IonSpinner,
   IonTitle,
   IonToolbar,
@@ -21,7 +20,7 @@ const PageStructView = ({
   showIndicator,
 }: PageStructProps): React.FunctionComponentElement<PageStructProps> => {
   return (
-    <IonPage>
+    <>
       <IonHeader>
         <IonToolbar color="primary">
           <IonButtons slot="start">
@@ -37,7 +36,7 @@ const PageStructView = ({
         {showNextFab ? <NextFab /> : null}
         {children}
       </IonContent>
-    </IonPage>
+    </>
   );
 };
 

--- a/app/src/components/SideMenu/SideMenu.View.tsx
+++ b/app/src/components/SideMenu/SideMenu.View.tsx
@@ -21,8 +21,9 @@ import React from 'react';
 const SideMenuView = ({
   categoryStructure,
   enterView,
+  contentId,
 }: SideMenuProps): JSX.Element => (
-  <IonMenu contentId="main">
+  <IonMenu contentId={contentId}>
     <IonHeader>
       <IonToolbar color="primary">
         <IonTitle>Snowman - Benchmark</IonTitle>

--- a/app/src/components/SideMenu/SideMenuProps.ts
+++ b/app/src/components/SideMenu/SideMenuProps.ts
@@ -14,6 +14,10 @@ export interface SideMenuCategory {
   categoryItems: CategoryItem[];
 }
 
+export interface SideMenuOwnProps {
+  contentId: string;
+}
+
 export interface SideMenuDispatchProps {
   enterView(aViewId: ViewIDs): void;
 }
@@ -22,4 +26,6 @@ export interface SideMenuStateProps {
   categoryStructure: SideMenuCategory[];
 }
 
-export type SideMenuProps = SideMenuStateProps & SideMenuDispatchProps;
+export type SideMenuProps = SideMenuOwnProps &
+  SideMenuStateProps &
+  SideMenuDispatchProps;


### PR DESCRIPTION
This PR resolves bug introduced with PR #74. We cannot replace IonicPages completely - replacing only its content works though.