### PR TITLE
Fix calculation of total count

### DIFF
--- a/app/src/pages/BinaryMetricsPage/BinaryMetricsPage.tsx
+++ b/app/src/pages/BinaryMetricsPage/BinaryMetricsPage.tsx
@@ -25,6 +25,7 @@ import { Store } from 'store/models';
 import { MetricsTuplesCategories } from 'types/MetricsTuplesCategories';
 import { TuplesLoader } from 'types/TuplesLoader';
 import { intersectionDescription } from 'utils/intersectionDescription';
+import { numberOfDistinctPairs } from 'utils/numberOfDistinctPairs';
 
 const getCountsByTuplesCategory = (
   store: Store,
@@ -118,9 +119,8 @@ const mapStateToProps = (state: Store): BinaryMetricsPageStateProps => ({
     state.BinaryMetricsStore.selectedDataView
   ),
   confusionMatrix: {
-    totalCount: Math.pow(
-      state.BenchmarkConfigurationStore.selectedDataset?.numberOfRecords ?? 0,
-      2
+    totalCount: numberOfDistinctPairs(
+      state.BenchmarkConfigurationStore.selectedDataset?.numberOfRecords ?? 0
     ),
     falseNegatives: getPairCountByTuplesCategory(
       state,

--- a/app/src/utils/numberOfDistinctPairs.ts
+++ b/app/src/utils/numberOfDistinctPairs.ts
@@ -1,0 +1,2 @@
+export const numberOfDistinctPairs = (size: number): number =>
+  (size * (size - 1)) / 2;


### PR DESCRIPTION
The formula use to calculate the total pair count on the binary metrics page was wrong. We now use the gaussian formulae to calculate the amount of distinct pairs.